### PR TITLE
Added project.json.

### DIFF
--- a/Deadlock.Robinhood/project.json
+++ b/Deadlock.Robinhood/project.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.2",
+  "buildOptions": {
+    "debugType": "portable"
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "8.0.2"
+  },
+  "frameworks": {
+    "netcoreapp1.1": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.1.0"
+        }
+      },
+      "imports": "dnxcore50"
+    }
+  }
+}


### PR DESCRIPTION
I'm trying to use this library in a .NET Core application and it is currently missing target framework definition. I've created a `project.json` file based on the latest `packages.config`.